### PR TITLE
Mention elf.h build requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ program is similar to how WINE works.
 Note that all commands below assumes you have all of my submission in
 the current directory.
 
+> ⚠ If you are on Mac OS X, you will need to obtain a
+> copy of `elf.h` somehow and place/symlink it inside `/usr/local/include`.
+> I got mine from installing the `i386-elf-gcc` package from MacPorts and
+> making a symlink at `/usr/local/include/elf.h` pointing to
+> `/opt/local/i386-elf/include/elf.h`.
+
 ### Usage for Linux and Mac OSX
 
     $ make

--- a/mkenv.sh
+++ b/mkenv.sh
@@ -9,15 +9,27 @@ extract_deb() {
         curl -O $url || wget $url
     fi
     ar x $deb
-    tar -xvzf data.tar.gz
+    case $(ar -t "$deb" | grep '^data\.tar' | sed 's/^data\.tar\.//') in
+        xz)
+            xzcat data.tar.xz | tar -xvf -
+            ;;
+        gz)
+            tar -xvzf data.tar.gz
+            ;;
+        *)
+            (echo "Unhandled data.tar.* format!" >&2)
+            exit 1
+            ;;
+    esac
 }
 
 mkdir -p linux
 cd linux
 
-extract_deb http://ftp.debian.org/debian/pool/main/e/eglibc/libc6_2.11.3-4_i386.deb
-extract_deb http://ftp.debian.org/debian/pool/main/e/eglibc/libc6-dev_2.11.3-4_i386.deb
-extract_deb http://ftp.debian.org/debian/pool/main/l/linux-2.6/linux-libc-dev_2.6.32-48squeeze4_i386.deb
+extract_deb http://archive.debian.org/debian/pool/main/e/eglibc/libc6_2.11.3-4_i386.deb
+extract_deb http://archive.debian.org/debian/pool/main/e/eglibc/libc6-dev_2.11.3-4_i386.deb
+extract_deb http://archive.debian.org/debian/pool/main/l/linux-2.6/linux-libc-dev_2.6.32-48squeeze6_i386.deb
+
 tar -xvzf ../tcc.tgz
 
 perl -i -p -e 's@ /@ '$(pwd)/'@g' usr/lib/libc.so


### PR DESCRIPTION
On my Darwin 10 Machine (Mac OS X 10.6.8 Snow Leopard), it is necessary
to obtain ELF headers.  I got it by installing i386-elf-gcc from
MacPorts.  This should be relevant to newer releases as well, though the
location of the symlink will be different on newer releases of macOS
(Apple no longer has /usr/include, iirc).  Once I get my macOS Catalina
install back up and running, I will update the note to include
appropriate symlink locations for newer releases, as well.