### PR TITLE
Add local README preview to Makefile with Pandoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ LDFLAGS+=-rdynamic
 ifeq ($(UNAME),Linux)
 	LDFLAGS+=-ldl
 	LDFLAGS+=-Wl,-Ttext-segment=0x2000000
+	OPEN=xdg-open
+endif
+ifeq ($(detected_OS),Darwin)
+	OPEN=open
 endif
 
 all: el elg elf elf-tiny elf-clean elf-clean64
@@ -42,3 +46,10 @@ elf-clean: elf-clean.o
 
 clean:
 	rm -f el elg elf *.o
+
+pub-css:
+	-[ ! -e pub.css ] && wget https://github.com/manuelp/pandoc-stylesheet/raw/acac36b976966f76544176161ba826d519b6f40c/pub.css
+
+README: pub-css # Requires Pandoc to be installed
+	pandoc README.md -s -c pub.css -o README.html
+	$(OPEN) README.html

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ program is similar to how WINE works.
 Note that all commands below assumes you have all of my submission in
 the current directory.
 
+> ⚠ If you are on Mac OS X, you will need to obtain a
+> copy of `elf.h` somehow and place/symlink it inside `/usr/local/include`.
+> I got mine from installing the `i386-elf-gcc` package from MacPorts and
+> making a symlink at `/usr/local/include/elf.h` pointing to
+> `/opt/local/i386-elf/include/elf.h`.
+
 ### Usage for Linux and Mac OSX
 
     $ make

--- a/mkenv.sh
+++ b/mkenv.sh
@@ -9,15 +9,27 @@ extract_deb() {
         curl -O $url || wget $url
     fi
     ar x $deb
-    tar -xvzf data.tar.gz
+    case $(ar -t "$deb" | grep '^data\.tar' | sed 's/^data\.tar\.//') in
+        xz)
+            xzcat data.tar.xz | tar -xvf -
+            ;;
+        gz)
+            tar -xvzf data.tar.gz
+            ;;
+        *)
+            (echo "Unhandled data.tar.* format!" >&2)
+            exit 1
+            ;;
+    esac
 }
 
 mkdir -p linux
 cd linux
 
-extract_deb http://ftp.debian.org/debian/pool/main/e/eglibc/libc6_2.11.3-4_i386.deb
-extract_deb http://ftp.debian.org/debian/pool/main/e/eglibc/libc6-dev_2.11.3-4_i386.deb
-extract_deb http://ftp.debian.org/debian/pool/main/l/linux-2.6/linux-libc-dev_2.6.32-48squeeze4_i386.deb
+extract_deb http://archive.debian.org/debian/pool/main/e/eglibc/libc6_2.11.3-4_i386.deb
+extract_deb http://archive.debian.org/debian/pool/main/e/eglibc/libc6-dev_2.11.3-4_i386.deb
+extract_deb http://archive.debian.org/debian/pool/main/l/linux-2.6/linux-libc-dev_2.6.32-48squeeze6_i386.deb
+
 tar -xvzf ../tcc.tgz
 
 perl -i -p -e 's@ /@ '$(pwd)/'@g' usr/lib/libc.so


### PR DESCRIPTION
This commit adds the ability to locally preview README.md in your
browser using Pandoc.  It pulls in a CSS stylesheet pinned at a known
good commit (for supply chain safety/security) to make the preview
easier on the eyes.

Red Hat/Fedora/MSys2 users may not have xdg-open installed.  Sorry.  (Patches
welcome!)